### PR TITLE
Improve performance of HaveWatchOnly (used in listunspent)

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -112,3 +112,10 @@ bool CBasicKeyStore::HaveWatchOnly() const
     LOCK(cs_KeyStore);
     return (!setWatchOnly.empty());
 }
+
+std::size_t hash_value(const CScript& p)
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, ToByteVector(p));
+    return seed;
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -14,6 +14,11 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/variant.hpp>
+#include <boost/unordered_set.hpp>
+
+// Definition of hash_value for CScript (to be used in boost::unordered_set)
+std::size_t hash_value(const CScript& p);
+
 
 /** A virtual base class for key stores */
 class CKeyStore
@@ -49,7 +54,7 @@ public:
 typedef std::map<CKeyID, CKey> KeyMap;
 typedef std::map<CKeyID, CPubKey> WatchKeyMap;
 typedef std::map<CScriptID, CScript > ScriptMap;
-typedef std::set<CScript> WatchOnlySet;
+typedef boost::unordered_set<CScript> WatchOnlySet;
 
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -461,6 +461,17 @@ public:
         return *this;
     }
 
+    bool operator<(const CScript& other) const
+    {
+        if (size() < other.size()) {
+            return true;
+        }
+        if (size() > other.size()) {
+            return false;
+        }
+        return memcmp(this, &other, size()) < 0;
+    }
+
     CScript& operator<<(const CScript& b)
     {
         // I'm not sure if this should push the script or concatenate scripts.


### PR DESCRIPTION
In the call HaveWatchOnly it checks if a given CScript is present in a set of Watch-only addresses set (set<CScript> loaded into memory) to mark it as watch-only "script".

Instead of using an ordered set (std::set) we use the boost::unordered_set, by that we improve the performance by ~30%.

The general performance of the call listunspent improves by ~20%.

@promag @jpdffonseca 
