### PR TITLE
Add options to listunspent rpc call

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -68,6 +68,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent", 0 },
     { "listunspent", 1 },
     { "listunspent", 2 },
+    { "listunspent", 3 },
     { "getblock", 1 },
     { "getblockheader", 1 },
     { "gettransaction", 1 },


### PR DESCRIPTION
Add options to `listunspent` rpc call:
- Remove address information
- Remove **0 value** UTXO's

Increases **listunspent** performance.

@promag @jpdffonseca 
