### PR TITLE
Add index of transaction outpoints

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -600,7 +600,7 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) 
         int nDepth = wallet->mapWallet[outpoint.hash].GetDepthInMainChain();
         if (nDepth < 0) continue;
         COutput out(&wallet->mapWallet[outpoint.hash], outpoint.n, nDepth, true, true);
-        if (outpoint.n < out.tx->vout.size() && wallet->IsMine(out.tx->vout[outpoint.n]) == ISMINE_SPENDABLE)
+        if (outpoint.n < out.tx->vout.size() && wallet->IsMine(outpoint) == ISMINE_SPENDABLE)
             vCoins.push_back(out);
     }
 
@@ -608,7 +608,7 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) 
     {
         COutput cout = out;
 
-        while (wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0 && wallet->IsMine(cout.tx->vin[0]))
+        while (wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0 && wallet->IsMine(cout.tx->vin[0].prevout))
         {
             if (!wallet->mapWallet.count(cout.tx->vin[0].prevout.hash)) break;
             cout = COutput(&wallet->mapWallet[cout.tx->vin[0].prevout.hash], cout.tx->vin[0].prevout.n, 0, true, true);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -629,6 +629,10 @@ public:
         fBroadcastTransactions = false;
     }
 
+    std::map<COutPoint, std::pair<CTxOut, isminetype>> mapOutPoints;
+    void UpdateOutPointsIndex();
+    void AddOutPointsToIndex(const CWalletTx& wtx);
+
     std::map<uint256, CWalletTx> mapWallet;
     std::list<CAccountingEntry> laccentries;
 
@@ -783,6 +787,7 @@ public:
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
+    isminetype IsMine(const COutPoint& outpoint) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
     bool IsChange(const CTxOut& txout) const;
     CAmount GetChange(const CTxOut& txout) const;


### PR DESCRIPTION
#### Description

This PR adds an index to keep the value of the `isminetype` value for each Tx output. 

There are several places where `IsMine()` is called to determine the "solvability" and "spendability" of an address, and each of those times that value is computed, according to the keys stored on our wallet. 

Since this value doesn't change that much (except when we import an address or a key regarding an already imported address), we can keep those values _cached_ for faster lookups.

Some of the rpc calls greatly affected by this overhead are `listunspent` and `fundrawtransaction`, because of the work that is being done by their internal call `CWallet::AvailableCoins(...)`.

This changes should improve `CWallet::AvailableCoins(...)` performance **up to 70%**, depending on the wallet's size.
